### PR TITLE
Update Flurry DFP/ADMob adapter podspec

### DIFF
--- a/AdMobMediationAdapterFlurry.podspec
+++ b/AdMobMediationAdapterFlurry.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
 	spec.name               = 'AdMobMediationAdapterFlurry'
-	spec.version            = '7.9.2'
+	spec.version            = '8.2.1'
 	spec.summary            = 'Flurry adapter for Google Ads SDK'
 	spec.license            = { :type => 'Commercial', :file => 'Licenses/Flurry-LICENSE.txt' }
 	spec.description        = 'The Flurry adapter allows app publishers mediate the Flurry SDK using Google Ads for AdMob or DFP'
@@ -8,13 +8,13 @@ Pod::Spec.new do |spec|
 	spec.author             = { 'Flurry' => 'integration@flurry.com' }
 	spec.source             = { :git => 'https://github.com/flurry/flurry-adapter-admob-ios.git', :tag => spec.version.to_s }
 	spec.requires_arc       = false
-	spec.platforms          = { :ios => '7.0' }
+	spec.platforms          = { :ios => '8.0' }
 	spec.source_files       = [
 		'FlurryAdapter/FlurryAdNetworkExtras.h'
 	]
 	spec.vendored_libraries  = 'FlurryAdapter/libFlurryAdapter.a'
-	spec.dependency 'Flurry-iOS-SDK/FlurrySDK', '~> 7'
-	spec.dependency 'Flurry-iOS-SDK/FlurryAds', '~> 7'
+	spec.dependency 'Flurry-iOS-SDK/FlurrySDK', '~> 8'
+	spec.dependency 'Flurry-iOS-SDK/FlurryAds', '~> 8'
 	spec.dependency 'Google-Mobile-Ads-SDK', '~> 7.12'
 end
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Flurry iOS Adapter for AdMob and DFP
 
 [![Cocoapods pod version](https://img.shields.io/cocoapods/v/AdMobMediationAdapterFlurry.svg?style=flat)](https://cocoapods.org/pods/AdMobMediationAdapterFlurry)
 
-### Adapter version 7.9.2 - Updated 2017-02-10
+### Adapter version 8.2.1 - Updated 2017-09-19
 
 This adapter enables mediation of Flurry ads via the Google Ads SDK for 
 [DoubleClick for Publishers](https://developers.google.com/mobile-ads-sdk/docs/dfp/ios/mediation-networks) or 


### PR DESCRIPTION
Update adapter pod spec to Flurry sdk 8+
iOS 8.0 is now the minimum version for Flurry ads